### PR TITLE
Allow creation of A records for the root domain

### DIFF
--- a/Validator/Constraints/RecordValidator.php
+++ b/Validator/Constraints/RecordValidator.php
@@ -378,7 +378,7 @@ class RecordValidator extends ConstraintValidator
             // Check the hostname only if necessary
             if (!$record->getLooseCheck()) {
                 // First check if we're in the domain.
-                if (false === strpos($name, '.'.$record->getDomain()->getName())) {
+                if ($name != $record->getDomain()->getName() && strpos($name, '.'.$record->getDomain()->getName()) === false) {
                     $this->context->addViolationAt('name',
                         'Name: '.$name.' is not in domain: '.$record->getDomain()->getName(),
                         array(), null);


### PR DESCRIPTION
If you have a domain like example.com and you try to create an A record for example.com, then the validator fails. This fixes the problem.
